### PR TITLE
Bug Fix: Intially Fruit score showed high score

### DIFF
--- a/main.py
+++ b/main.py
@@ -285,10 +285,6 @@ class game:
                 pickle.dump(0, output, pickle.HIGHEST_PROTOCOL)
                 pickle.dump(0, output, pickle.HIGHEST_PROTOCOL)
 
-        with open(self.score_path, 'rb') as input:  # REading
-            fruitscore = pickle.load(input)
-            fruitscore = pickle.load(input)
-
         scoreshift = 0
         fruitscoreshift = 0
         shift1 = 1


### PR DESCRIPTION
## Overview 
Intially the fruitscore used to display the highscore instead of zero, fixed it by setting it to display zero as it is supposed to

Before the bug fix
![screenshot1](https://user-images.githubusercontent.com/96080203/217227550-671bd879-8173-4469-a4e7-8737963ce3f8.jpg)

After the bug fix
![Screenshot2](https://user-images.githubusercontent.com/96080203/217227852-c57a98e1-26c4-4fbf-8ac1-b4c06c491e44.png)

## Test
Practically playing no bugs related to the new modifications were found

## Reference
Fixed it by removing 
```
        with open(self.score_path, 'rb') as input:  # REading
            fruitscore = pickle.load(input)
            fruitscore = pickle.load(input)
```
which initially sets it which was redundant