### PR TITLE
Bug Fix for the perfect Score

### DIFF
--- a/main.py
+++ b/main.py
@@ -646,7 +646,7 @@ class game:
                     colortest = gameDisplay.get_at(
                         (int(sx(457, 1) + sticklength), int(heroy + sy(30))))
 
-                    if(colortest[0] == 255):
+                    if(colortest[0] == 255 and colortest[1] == 0 and colortest[2] == 0):
                         perfectflag = 1
                         perfectsound.play()
                         perfect = 1


### PR DESCRIPTION
## Overview
Fixed a bug : Perfect score was shown incorrectly due to incomplete colortest

## Steps to replicate bugs
1. Play the game and make it so that the stick lands on a white pixel
2. Notice that the game shows +1 perfect even though we didn't make the stick land at the red spot in the center of a pillar

## Expected Behavior
The game is only supposed to show perfect when we land on a red pixel 

## Cause 
The colortest for perfect score was done in the following manner 
```
if(colortest[0] == 255):
```
which only checks the Red value in the RGB spectrum 
so even a whitespace would match the check as Red value of white is also 255 as is for any other color with R value of 255

## Fix
To fix this I have simply set the colortest to check all r g and b values of the rgb spectrum in the following manner
```
if(colortest[0] == 255 and colortest[1] == 0 and colortest[2] == 0):
```

this ensures red and only red pixels trigger the perfect score 

## Screenshot
![screenshot1](https://user-images.githubusercontent.com/96080203/218313969-79ac251f-071b-4d0b-a127-aec8e602d5a5.jpg)

> Here is a demonstration of how the bug plays out

